### PR TITLE
Added main key for bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,10 @@
   "homepage": "https://github.com/Zhouzi/linkhunter",
   "authors": ["Gabin <hello@gabinaureche.com>"],
   "description": "Detect links that real users actually type.",
+  "main": [
+    "./dist/linkhunter.min.js",
+    "./dist/linkhunter-angular.min.js"
+  ],
   "license": "MIT",
   "ignore": [
     ".*",

--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,7 @@
   "homepage": "https://github.com/Zhouzi/linkhunter",
   "authors": ["Gabin <hello@gabinaureche.com>"],
   "description": "Detect links that real users actually type.",
-  "main": [
-    "./dist/linkhunter.min.js",
-    "./dist/linkhunter-angular.min.js"
-  ],
+  "main": ["./dist/linkhunter.min.js"],
   "license": "MIT",
   "ignore": [
     ".*",


### PR DESCRIPTION
I specified the main key in the bower.json file.  I did mainly to allow other libraries such as [Wiredep](https://github.com/taptapship/wiredep) to pick out the related js files.